### PR TITLE
Fix MaloIdent component schema refs for Redocly bundling

### DIFF
--- a/maloident-lieferant/components/schemas/MALOIDENTANTWORT_NEGATIV.yml
+++ b/maloident-lieferant/components/schemas/MALOIDENTANTWORT_NEGATIV.yml
@@ -101,7 +101,7 @@ properties:
                 description: "Identifiziert den Marktpartner (Marktpartner-ID)."
                 example: "9980000000029"            
               rollencodetyp:
-                $ref: "#/components/schemas/Rollencodetyp"                
+                $ref: "../../../_schemas/openapi.yml#/components/schemas/Rollencodetyp"                
             required:
               - boTyp
               - versionStruktur 

--- a/maloident-lieferant/components/schemas/MALOIDENTANTWORT_POSITIV.yml
+++ b/maloident-lieferant/components/schemas/MALOIDENTANTWORT_POSITIV.yml
@@ -32,12 +32,12 @@ properties:
                     Identifiziert die Marktlokation mittels einer eindeutigen ID
                     | Mapping auf dataMarketLocation.maloId                   
                 energierichtung:
-                  $ref: "#/components/schemas/Energierichtung"
+                  $ref: "../../../_schemas/openapi.yml#/components/schemas/Energierichtung"
                   description: > 
                     Energieflussrichtung der Marktlokation
                     | Mapping auf dataMarketLocation.energyDirection          
                 messtechnischeEinordnung:
-                  $ref: "#/components/schemas/MesstechnischeEinordnung"
+                  $ref: "../../../_schemas/openapi.yml#/components/schemas/MesstechnischeEinordnung"
                   description: > 
                     Angabe der messtechnischen Einordung der Marktlokation
                     | Mapping auf dataMarketLocation.measurementTechnologyClassification     
@@ -47,7 +47,7 @@ properties:
                     type: object
                     properties:
                       typ:
-                        $ref: "#/components/schemas/MarktlokationsTyp"
+                        $ref: "../../../_schemas/openapi.yml#/components/schemas/MarktlokationsTyp"
                         description: "Eigenschaft der Marktlokation. RUHENDE_MARKTLOKATION=ruhende Marktlokation, KUNDENANLAGE=Marktlokation ist eine Kundenanlage, STANDARD_MARKTLOKATION=alle 'Standard' Marktlokationen."                 
                       gueltigAb:
                         type: string
@@ -58,7 +58,7 @@ properties:
                         description: "Endezeitpunkt, Zeitpunkt bis zu dem die zugeordneten Marktpartner oder Lokationen zugeordnet werden. Dieser Zeitpunkt muss ein Tagesbeginn 00:00 Uhr gesetzlicher deutscher Zeit sein."
                         example: "2023-09-01T22:00:00Z"                                                                    
                 lokationsadresse:
-                  $ref: "#/components/schemas/Adresse"
+                  $ref: "../../../_schemas/openapi.yml#/components/schemas/Adresse"
                   description: > 
                     Angabe des Ortes, Postleitzahl, Ländercode, Straße, Hausnummer, Hausnummernergänzung der Marktlokationsadresse
                     | Mapping auf dataMarketLocation.dataMarketLocationAddress                    
@@ -81,7 +81,7 @@ properties:
                         enum: 
                           - "1"                          
                       marktrolle:
-                        $ref: "#/components/schemas/Marktrolle"                                          
+                        $ref: "../../../_schemas/openapi.yml#/components/schemas/Marktrolle"                                          
                       rollencodenummer:
                         type: string
                         description: "Identifiziert den Marktpartner (Marktpartner-ID)."
@@ -104,12 +104,12 @@ properties:
                       - zuordnungVon        
                       - zuordnungBis                       
                 katasterinformation:
-                  $ref: "#/components/schemas/Katasteradresse"
+                  $ref: "../../../_schemas/openapi.yml#/components/schemas/Katasteradresse"
                   description: > 
                     Angabe des Gemarkungsnamens, Flurnummer, Flurstücksnummer (des Flurstücks) der Marktlokationsadresse
                     | Mapping auf dataMarketLocation.dataMarketLocationLandParcels                    
                 geokoordinaten:
-                  $ref: "#/components/schemas/Geokoordinaten"                
+                  $ref: "../../../_schemas/openapi.yml#/components/schemas/Geokoordinaten"                
                   description: > 
                     Angabe der Breite (Breitengrad), Angabe der Breite (Breitengrad), UTM Ostwert, UTM Nordwert, Gauß-Krüger Hochwert, Gauß-Krüger Rechtswert 
                     | Mapping auf dataMarketLocation.dataMarketLocationGeographicCoordinates                                        
@@ -134,7 +134,7 @@ properties:
                   enum: 
                     - "1"
                 wahlrechtPrognosegrundlage:
-                  $ref: "#/components/schemas/WahlrechtPrognosegrundlage"
+                  $ref: "../../../_schemas/openapi.yml#/components/schemas/WahlrechtPrognosegrundlage"
                   description: > 
                     Wahlrecht zur Änderung der Prognosegrundlage
                     | Mapping auf optionalChangeForecastBasis   
@@ -165,10 +165,10 @@ properties:
                     | Mapping auf identificationParameterId.tranchenIds    
                 bildungTranchengroesse:
                   description: "Gibt die Bildungslogik der Tranche an."
-                  $ref: "#/components/schemas/BildungTranchengroesse"
+                  $ref: "../../../_schemas/openapi.yml#/components/schemas/BildungTranchengroesse"
                 aufteilungsmenge:
                   description: "Gibt die Bildungslogik der Tranche an."
-                  $ref: "#/components/schemas/Menge"           
+                  $ref: "../../../_schemas/openapi.yml#/components/schemas/Menge"           
                 marktrollen:
                   type: array
                   description: > 

--- a/maloident-macoapp/components/schemas/START_MALOIDENT.yml
+++ b/maloident-macoapp/components/schemas/START_MALOIDENT.yml
@@ -29,22 +29,22 @@ properties:
                 Identifiziert die Marktlokation mittels einer eindeutigen ID
                 | Mapping auf identificationParameterId.maloId                   
             energierichtung:
-              $ref: "#/components/schemas/Energierichtung"
+              $ref: "../../../_schemas/openapi.yml#/components/schemas/Energierichtung"
               description: > 
                 Energieflussrichtung der Marktlokation
                 | Mapping auf energyDirection                    
             lokationsadresse:
-              $ref: "#/components/schemas/Adresse"
+              $ref: "../../../_schemas/openapi.yml#/components/schemas/Adresse"
               description: > 
                 Angabe des Ortes, Postleitzahl, Ländercode, Straße, Hausnummer, Hausnummernergänzung der Marktlokationsadresse
                 | Mapping auf identificationParameterAddress                    
             katasterinformation:
-              $ref: "#/components/schemas/Katasteradresse"
+              $ref: "../../../_schemas/openapi.yml#/components/schemas/Katasteradresse"
               description: > 
                 Angabe des Gemarkungsnamens, Flurnummer, Flurstücksnummer (des Flurstücks) der Marktlokationsadresse
                 | Mapping auf identificationParameterAddress.landParcels                    
             geokoordinaten:
-              $ref: "#/components/schemas/Geokoordinaten"                
+              $ref: "../../../_schemas/openapi.yml#/components/schemas/Geokoordinaten"                
               description: > 
                 Angabe der Breite (Breitengrad), Angabe der Breite (Breitengrad), UTM Ostwert, UTM Nordwert, Gauß-Krüger Hochwert, Gauß-Krüger Rechtswert 
                 | Mapping auf identificationParameterAddress.geographicCoordinates                    
@@ -291,4 +291,3 @@ required:
   - stammdaten
   - transaktionsdaten
   - zusatzdaten                      
-

--- a/maloident-netzbetreiber/components/schemas/LESEN_MALOIDENT_MARKTLOKATION.yml
+++ b/maloident-netzbetreiber/components/schemas/LESEN_MALOIDENT_MARKTLOKATION.yml
@@ -29,12 +29,12 @@ properties:
                 Identifiziert die Marktlokation mittels einer eindeutigen ID
                 | Mapping auf dataMarketLocation.maloId                   
             energierichtung:
-              $ref: "#/components/schemas/Energierichtung"
+              $ref: "../../../_schemas/openapi.yml#/components/schemas/Energierichtung"
               description: > 
                 Energieflussrichtung der Marktlokation
                 | Mapping auf dataMarketLocation.energyDirection          
             messtechnischeEinordnung:
-              $ref: "#/components/schemas/MesstechnischeEinordnung"
+              $ref: "../../../_schemas/openapi.yml#/components/schemas/MesstechnischeEinordnung"
               description: > 
                 Angabe der messtechnischen Einordung der Marktlokation
                 | Mapping auf dataMarketLocation.measurementTechnologyClassification     
@@ -44,7 +44,7 @@ properties:
                 type: object
                 properties:
                   typ:
-                    $ref: "#/components/schemas/MarktlokationsTyp"
+                    $ref: "../../../_schemas/openapi.yml#/components/schemas/MarktlokationsTyp"
                     description: "Eigenschaft der Marktlokation. RUHENDE_MARKTLOKATION=ruhende Marktlokation, KUNDENANLAGE=Marktlokation ist eine Kundenanlage, STANDARD_MARKTLOKATION=alle 'Standard' Marktlokationen."                 
                   gueltigAb:
                     type: string
@@ -55,7 +55,7 @@ properties:
                     description: "Endezeitpunkt, Zeitpunkt bis zu dem die zugeordneten Marktpartner oder Lokationen zugeordnet werden. Dieser Zeitpunkt muss ein Tagesbeginn 00:00 Uhr gesetzlicher deutscher Zeit sein."
                     example: "2023-09-01T22:00:00Z"                                                                    
             lokationsadresse:
-              $ref: "#/components/schemas/Adresse"
+              $ref: "../../../_schemas/openapi.yml#/components/schemas/Adresse"
               description: > 
                 Angabe des Ortes, Postleitzahl, Ländercode, Straße, Hausnummer, Hausnummernergänzung der Marktlokationsadresse
                 | Mapping auf dataMarketLocation.dataMarketLocationAddress                    
@@ -78,7 +78,7 @@ properties:
                     enum: 
                       - "1"                          
                   marktrolle:
-                    $ref: "#/components/schemas/Marktrolle"                                          
+                    $ref: "../../../_schemas/openapi.yml#/components/schemas/Marktrolle"                                          
                   rollencodenummer:
                     type: string
                     description: "Identifiziert den Marktpartner (Marktpartner-ID)."
@@ -101,12 +101,12 @@ properties:
                   - zuordnungVon        
                   - zuordnungBis                       
             katasterinformation:
-              $ref: "#/components/schemas/Katasteradresse"
+              $ref: "../../../_schemas/openapi.yml#/components/schemas/Katasteradresse"
               description: > 
                 Angabe des Gemarkungsnamens, Flurnummer, Flurstücksnummer (des Flurstücks) der Marktlokationsadresse
                 | Mapping auf dataMarketLocation.dataMarketLocationLandParcels                    
             geokoordinaten:
-              $ref: "#/components/schemas/Geokoordinaten"                
+              $ref: "../../../_schemas/openapi.yml#/components/schemas/Geokoordinaten"                
               description: > 
                 Angabe der Breite (Breitengrad), Angabe der Breite (Breitengrad), UTM Ostwert, UTM Nordwert, Gauß-Krüger Hochwert, Gauß-Krüger Rechtswert 
                 | Mapping auf dataMarketLocation.dataMarketLocationGeographicCoordinates                                        
@@ -131,7 +131,7 @@ properties:
               enum: 
                 - "1"
             wahlrechtPrognosegrundlage:
-              $ref: "#/components/schemas/WahlrechtPrognosegrundlage"
+              $ref: "../../../_schemas/openapi.yml#/components/schemas/WahlrechtPrognosegrundlage"
               description: > 
                 Wahlrecht zur Änderung der Prognosegrundlage
                 | Mapping auf optionalChangeForecastBasis   
@@ -162,10 +162,10 @@ properties:
                 | Mapping auf identificationParameterId.tranchenIds    
             bildungTranchengroesse:
               description: "Gibt die Bildungslogik der Tranche an."
-              $ref: "#/components/schemas/BildungTranchengroesse"
+              $ref: "../../../_schemas/openapi.yml#/components/schemas/BildungTranchengroesse"
             aufteilungsmenge:
               description: "Gibt die Bildungslogik der Tranche an."
-              $ref: "#/components/schemas/Menge"           
+              $ref: "../../../_schemas/openapi.yml#/components/schemas/Menge"           
             marktrollen:
               type: array
               description: > 

--- a/maloident-netzbetreiber/components/schemas/START_MALOIDENT.yml
+++ b/maloident-netzbetreiber/components/schemas/START_MALOIDENT.yml
@@ -29,22 +29,22 @@ properties:
                 Identifiziert die Marktlokation mittels einer eindeutigen ID
                 | Mapping auf identificationParameterId.maloId                   
             energierichtung:
-              $ref: "#/components/schemas/Energierichtung"
+              $ref: "../../../_schemas/openapi.yml#/components/schemas/Energierichtung"
               description: > 
                 Energieflussrichtung der Marktlokation
                 | Mapping auf energyDirection                    
             lokationsadresse:
-              $ref: "#/components/schemas/Adresse"
+              $ref: "../../../_schemas/openapi.yml#/components/schemas/Adresse"
               description: > 
                 Angabe des Ortes, Postleitzahl, Ländercode, Straße, Hausnummer, Hausnummernergänzung der Marktlokationsadresse
                 | Mapping auf identificationParameterAddress                    
             katasterinformation:
-              $ref: "#/components/schemas/Katasteradresse"
+              $ref: "../../../_schemas/openapi.yml#/components/schemas/Katasteradresse"
               description: > 
                 Angabe des Gemarkungsnamens, Flurnummer, Flurstücksnummer (des Flurstücks) der Marktlokationsadresse
                 | Mapping auf identificationParameterAddress.landParcels                    
             geokoordinaten:
-              $ref: "#/components/schemas/Geokoordinaten"                
+              $ref: "../../../_schemas/openapi.yml#/components/schemas/Geokoordinaten"                
               description: > 
                 Angabe der Breite (Breitengrad), Angabe der Breite (Breitengrad), UTM Ostwert, UTM Nordwert, Gauß-Krüger Hochwert, Gauß-Krüger Rechtswert 
                 | Mapping auf identificationParameterAddress.geographicCoordinates                    
@@ -249,4 +249,3 @@ properties:
 required:
   - stammdaten
   - transaktionsdaten                  
-


### PR DESCRIPTION
Here is your Pull Request:

**Title:** `Fix MaloIdent component schema refs for Redocly bundling`

**Link:** [https://github.com/adriansprk/maco-api-documentation/pull/new/fix/maloident-component-schema-refs](https://github.com/adriansprk/maco-api-documentation/pull/new/fix/maloident-component-schema-refs)

---

## Summary

Fix broken `$ref` targets in MaloIdent component schema fragments so the OpenAPI bundles can be rebuilt locally with `@redocly/openapi-cli`.

## Problem

Several MaloIdent schema fragment files under `maloident-*/components/schemas/` use references like:

```yaml
$ref: "#/components/schemas/Energierichtung"
```

Those files are not top-level OpenAPI documents and do not define their own `components/schemas`. During bundling, Redocly resolves those refs against the fragment itself and fails with `Reference does not exist`.

This breaks schema rebuilds, for example:

```bash
npx @redocly/openapi-cli bundle maloident-macoapp/maloident-macoapp.yaml
```

## Root Cause

The MaloIdent component schema files are external fragments referenced from the main MaloIdent entrypoint YAMLs. Their internal schema references must point to the shared BO4E schema source in `_schemas/openapi.yml`, not to `#/components/schemas/...` inside the fragment file.

## Changes

Updated broken schema refs in:

- `maloident-macoapp/components/schemas/START_MALOIDENT.yml`
- `maloident-netzbetreiber/components/schemas/START_MALOIDENT.yml`
- `maloident-netzbetreiber/components/schemas/LESEN_MALOIDENT_MARKTLOKATION.yml`
- `maloident-lieferant/components/schemas/MALOIDENTANTWORT_POSITIV.yml`
- `maloident-lieferant/components/schemas/MALOIDENTANTWORT_NEGATIV.yml`

Example change:

```yaml
$ref: "#/components/schemas/Energierichtung"
```

to:

```yaml
$ref: "../../../_schemas/openapi.yml#/components/schemas/Energierichtung"
```

## Verification

The following commands succeed after the fix:

```bash
npx @redocly/openapi-cli bundle maloident-macoapp/maloident-macoapp.yaml
npx @redocly/openapi-cli bundle maloident-netzbetreiber/maloident-netzbetreiber.yaml
./scripts/sync/rebuild-schemas.sh
```

## Notes

The build still emits many Redocly warnings about `$ref` siblings and missing `contact` metadata, but those are warnings only. The blocking rebuild failure was caused by unresolved schema references in the MaloIdent fragments.